### PR TITLE
Instrument and trace time module with mock interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "align_ext"
 version = "0.1.0"
 
@@ -75,6 +84,71 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "aster-bigtcp"
@@ -411,6 +485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +537,12 @@ version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -474,6 +559,12 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "component"
@@ -505,6 +596,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -674,6 +771,29 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -893,6 +1013,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "iced-x86"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1131,40 @@ dependencies = [
 [[package]]
 name = "jhash"
 version = "0.1.0"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json"
@@ -1243,6 +1427,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1567,21 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1535,6 +1740,35 @@ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "riscv"
@@ -1771,6 +2005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
+name = "time_demo"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "log",
+ "user_time",
+]
+
+[[package]]
 name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,6 +2159,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "user_time"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "log",
+]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,12 +2207,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1964,7 +2345,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1973,14 +2363,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1990,10 +2397,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2002,10 +2421,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2014,10 +2445,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2026,10 +2469,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ members = [
     "kernel/libs/typeflags-util",
     "kernel/libs/atomic-integer-wrapper",
     "kernel/libs/xarray",
+    "user_time",
+    "apps/time_demo",
 ]
 exclude = [
     "kernel/libs/comp-sys/cargo-component",

--- a/apps/time_demo/Cargo.toml
+++ b/apps/time_demo/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "time_demo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+user_time = { path = "../../user_time" }
+env_logger = "0.11"
+log = "0.4"
+
+[lints]
+workspace = true
+

--- a/apps/time_demo/src/main.rs
+++ b/apps/time_demo/src/main.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+
+fn main() {
+    env_logger::init();
+    user_time::init();
+
+    let start = user_time::get_real_time();
+    println!(
+        "start: {:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:09}",
+        start.year, start.month, start.day, start.hour, start.minute, start.second, start.nanos
+    );
+
+    let mono0 = user_time::read_monotonic_time();
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    let mono1 = user_time::read_monotonic_time();
+    println!(
+        "monotonic delta: {} ms",
+        (mono1 - mono0).as_millis()
+    );
+
+    let instant = user_time::read_instant();
+    println!("instant: {}s {}ns", instant.secs(), instant.nanos());
+
+    let trace = user_time::take_trace();
+    println!("trace entries: {}", trace.len());
+    for line in trace {
+        println!("trace: {}", line);
+    }
+}
+

--- a/tools/dfsan_instrument.sh
+++ b/tools/dfsan_instrument.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the target as LLVM IR and instrument with DataFlowSanitizer (dfsan)
+
+if ! command -v opt >/dev/null; then
+  echo "opt not found in PATH" >&2
+  exit 1
+fi
+if ! command -v clang >/dev/null; then
+  echo "clang not found in PATH" >&2
+  exit 1
+fi
+
+PKG=${1:-time_demo}
+BIN=${2:-time_demo}
+MODE=${3:-debug}
+
+if [ -f /usr/local/cargo/env ]; then
+  source /usr/local/cargo/env
+fi
+
+# Emit LLVM IR for the binary target
+RUSTFLAGS="--emit=llvm-ir" cargo rustc -p "$PKG" --bin "$BIN" -- -C debuginfo=1
+
+# Locate the produced IR for the binary under deps
+TARGET_DIR="target/${MODE}/deps"
+mapfile -t BCS < <(find "$TARGET_DIR" -maxdepth 1 -type f -name "${BIN}-*.ll" 2>/dev/null || true)
+
+if [ ${#BCS[@]} -eq 0 ]; then
+  echo "No LLVM IR found for time_demo under $TARGET_DIR" >&2
+  exit 1
+fi
+
+IR=${BCS[0]}
+OUT_LL=${IR%.ll}.dfsan.ll
+
+echo "Instrumenting $IR -> $OUT_LL"
+opt -passes=dfsan --dfsan-abilist=/dev/null -S "$IR" -o "$OUT_LL"
+
+echo "Instrumented IR at: $OUT_LL"
+

--- a/user_time/Cargo.toml
+++ b/user_time/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "user_time"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+chrono = { version = "0.4.38", default-features = true, features = ["clock"] }
+
+[lints]
+workspace = true
+

--- a/user_time/src/coeff.rs
+++ b/user_time/src/coeff.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use core::ops::Mul;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Coeff {
+    mult: u32,
+    shift: u32,
+    max_multiplier: u64,
+}
+
+impl Coeff {
+    pub fn new(numerator: u64, denominator: u64, max_multiplier: u64) -> Self {
+        let mut shift_acc: u32 = 32;
+        debug_assert!(max_multiplier < (1 << 40));
+        let mut tmp = max_multiplier >> 32;
+        while tmp > 0 {
+            tmp >>= 1;
+            shift_acc -= 1;
+        }
+
+        let mut shift = 32;
+        let mut mult = 0;
+        while shift > 0 {
+            mult = numerator << shift;
+            mult += denominator / 2;
+            mult /= denominator;
+            if (mult >> shift_acc) == 0 {
+                break;
+            }
+            shift -= 1;
+        }
+        Self { mult: mult as u32, shift, max_multiplier }
+    }
+
+    pub fn mult(&self) -> u32 { self.mult }
+    pub fn shift(&self) -> u32 { self.shift }
+}
+
+impl Mul<u64> for Coeff {
+    type Output = u64;
+    fn mul(self, rhs: u64) -> Self::Output {
+        debug_assert!(rhs <= self.max_multiplier);
+        (rhs * self.mult as u64) >> self.shift
+    }
+}
+
+impl Mul<u32> for Coeff {
+    type Output = u32;
+    fn mul(self, rhs: u32) -> Self::Output {
+        debug_assert!(rhs as u64 <= self.max_multiplier);
+        ((rhs as u64 * self.mult as u64) >> self.shift) as u32
+    }
+}
+

--- a/user_time/src/lib.rs
+++ b/user_time/src/lib.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Standalone user-mode time library adapted from kernel `aster-time`.
+//! This version removes direct `ostd` dependencies and replaces them
+//! with user-mode friendly stubs so it can build and run as a normal
+//! Rust library using `std`.
+
+#![deny(unsafe_code)]
+
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+use std::time::Duration as StdDuration;
+
+mod coeff;
+use coeff::Coeff;
+use chrono::{Datelike, Timelike};
+
+pub const NANOS_PER_SECOND: u32 = 1_000_000_000;
+
+// --------- Instant and ClockSource (adapted) ----------
+
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Instant {
+    secs: u64,
+    nanos: u32,
+}
+
+impl Instant {
+    pub const fn zero() -> Self {
+        Self { secs: 0, nanos: 0 }
+    }
+
+    pub fn new(secs: u64, nanos: u32) -> Self {
+        Self { secs, nanos }
+    }
+
+    pub fn secs(&self) -> u64 {
+        self.secs
+    }
+
+    pub fn nanos(&self) -> u32 {
+        self.nanos
+    }
+}
+
+impl From<StdDuration> for Instant {
+    fn from(value: StdDuration) -> Self {
+        Self {
+            secs: value.as_secs(),
+            nanos: value.subsec_nanos(),
+        }
+    }
+}
+
+impl std::ops::Add<StdDuration> for Instant {
+    type Output = Instant;
+    fn add(self, other: StdDuration) -> Self::Output {
+        let mut secs = self.secs + other.as_secs();
+        let mut nanos = self.nanos + other.subsec_nanos();
+        if nanos >= NANOS_PER_SECOND {
+            secs += 1;
+            nanos -= NANOS_PER_SECOND;
+        }
+        Instant::new(secs, nanos)
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct ClockSourceBase {
+    freq: u64,
+    max_delay_secs: u64,
+}
+
+impl ClockSourceBase {
+    fn new(freq: u64, max_delay_secs: u64) -> Self {
+        let max_delay_secs = std::cmp::max(2, max_delay_secs);
+        ClockSourceBase {
+            freq,
+            max_delay_secs,
+        }
+    }
+}
+
+pub struct ClockSource {
+    read_cycles: Arc<dyn Fn() -> u64 + Sync + Send>,
+    base: ClockSourceBase,
+    coeff: Coeff,
+    last_record: RwLock<(Instant, u64)>,
+}
+
+impl ClockSource {
+    pub fn new(freq: u64, max_delay_secs: u64, read_cycles: Arc<dyn Fn() -> u64 + Sync + Send>) -> Self {
+        let base = ClockSourceBase::new(freq, max_delay_secs);
+        debug_assert!(max_delay_secs < 600);
+        let coeff = Coeff::new(NANOS_PER_SECOND as u64, freq, max_delay_secs * freq);
+        Self { read_cycles, base, coeff, last_record: RwLock::new((Instant::zero(), 0)) }
+    }
+
+    fn calculate_instant(&self) -> (Instant, u64) {
+        let (instant_cycles, last_instant, last_cycles) = {
+            let (last_instant, last_cycles) = *self.last_record.read().unwrap();
+            ((self.read_cycles)(), last_instant, last_cycles)
+        };
+
+        let delta_nanos = {
+            let delta_cycles = instant_cycles - last_cycles;
+            self.cycles_to_nanos_lossy(delta_cycles)
+        };
+        let duration = StdDuration::from_nanos(delta_nanos);
+        (last_instant + duration, instant_cycles)
+    }
+
+    fn cycles_to_nanos_lossy(&self, cycles: u64) -> u64 {
+        let max_cycles = self.base.max_delay_secs * self.base.freq;
+        if cycles <= max_cycles {
+            self.coeff * cycles
+        } else {
+            log::warn!(
+                "ClockSource not reliable: cycles {} exceed max {} (s)",
+                cycles, max_cycles
+            );
+            self.coeff * max_cycles
+        }
+    }
+
+    fn update_last_record(&self, record: (Instant, u64)) {
+        *self.last_record.write().unwrap() = record;
+    }
+
+    pub fn read_cycles(&self) -> u64 { (self.read_cycles)() }
+    pub fn last_record(&self) -> (Instant, u64) { *self.last_record.read().unwrap() }
+    pub fn max_delay_secs(&self) -> u64 { self.base.max_delay_secs }
+    pub fn coeff(&self) -> &Coeff { &self.coeff }
+    pub fn freq(&self) -> u64 { self.base.freq }
+    pub(crate) fn calibrate(&self, instant_cycles: u64) { self.update_last_record((Instant::zero(), instant_cycles)); }
+    pub(crate) fn update(&self) { let (i, c) = self.calculate_instant(); self.update_last_record((i, c)); }
+    pub(crate) fn read_instant(&self) -> Instant { self.calculate_instant().0 }
+}
+
+// --------- Stubbed ostd-facing types/APIs ----------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SystemTime {
+    pub year: u16,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    pub nanos: u64,
+}
+
+impl SystemTime {
+    pub const fn zero() -> Self {
+        Self { year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0, nanos: 0 }
+    }
+}
+
+// A simple user-mode RTC stub that reads from std::time::SystemTime
+trait RtcDriver: Send + Sync {
+    fn read_rtc(&self) -> SystemTime;
+}
+
+struct StdRtc;
+impl RtcDriver for StdRtc {
+    fn read_rtc(&self) -> SystemTime {
+        let now = std::time::SystemTime::now();
+        let datetime: chrono::DateTime<chrono::Utc> = now.into();
+        let (is_ad, year) = datetime.year_ce();
+        debug_assert!(is_ad);
+        SystemTime {
+            year: year as u16,
+            month: datetime.month() as u8,
+            day: datetime.day() as u8,
+            hour: datetime.hour() as u8,
+            minute: datetime.minute() as u8,
+            second: datetime.second() as u8,
+            nanos: datetime.timestamp_subsec_nanos() as u64,
+        }
+    }
+}
+
+static RTC_DRIVER: OnceLock<Arc<dyn RtcDriver>> = OnceLock::new();
+static VDSO_DATA_HIGH_RES_UPDATE_FN: OnceLock<Arc<dyn Fn(Instant, u64) + Sync + Send>> = OnceLock::new();
+static READ_TIME: Mutex<SystemTime> = Mutex::new(SystemTime::zero());
+static START_TIME: OnceLock<SystemTime> = OnceLock::new();
+static CLOCK: OnceLock<Arc<ClockSource>> = OnceLock::new();
+
+const MAX_DELAY_SECS: u64 = 100;
+
+fn read_tsc_stub() -> u64 {
+    // Use a monotonic counter derived from std::time::Instant
+    static EPOCH: OnceLock<std::time::Instant> = OnceLock::new();
+    let base = EPOCH.get_or_init(std::time::Instant::now);
+    base.elapsed().as_nanos() as u64
+}
+
+fn tsc_freq_stub() -> u64 {
+    // We treat the stub cycles as nanoseconds, so 1e9 cycles/sec.
+    1_000_000_000
+}
+
+fn init_clock() {
+    CLOCK.get_or_init(|| {
+        Arc::new(ClockSource::new(tsc_freq_stub(), MAX_DELAY_SECS, Arc::new(read_tsc_stub)))
+    });
+}
+
+fn calibrate() {
+    let clock = CLOCK.get().unwrap();
+    let cycles = clock.read_cycles();
+    clock.calibrate(cycles);
+    START_TIME.get_or_init(read);
+}
+
+fn init_timer() {
+    // In user mode, spawn a background thread to periodically update the clocksource
+    let max_delay_secs = CLOCK.get().unwrap().max_delay_secs() >> 1;
+    let update_interval = std::time::Duration::from_secs(std::cmp::max(1, max_delay_secs));
+    std::thread::spawn(move || loop {
+        std::thread::sleep(update_interval);
+        update_clocksource();
+    });
+}
+
+fn update_clocksource() {
+    let clock = CLOCK.get().unwrap();
+    clock.update();
+    if let Some(update_fn) = VDSO_DATA_HIGH_RES_UPDATE_FN.get() {
+        let (last_instant, last_cycles) = clock.last_record();
+        update_fn(last_instant, last_cycles);
+    }
+}
+
+fn update_time() {
+    let mut lock = READ_TIME.lock().unwrap();
+    *lock = RTC_DRIVER.get_or_init(|| Arc::new(StdRtc)).read_rtc();
+}
+
+pub fn init() {
+    RTC_DRIVER.get_or_init(|| Arc::new(StdRtc));
+    init_clock();
+    calibrate();
+    init_timer();
+}
+
+pub fn get_real_time() -> SystemTime { trace_record("get_real_time"); read() }
+pub fn read() -> SystemTime { trace_record("read_time"); update_time(); READ_TIME.lock().unwrap().clone() }
+pub fn read_start_time() -> SystemTime { *START_TIME.get().expect("init() not called") }
+pub fn read_monotonic_time() -> StdDuration { let instant = read_instant(); StdDuration::new(instant.secs(), instant.nanos()) }
+pub fn default_clocksource() -> Arc<ClockSource> { CLOCK.get().expect("init() not called").clone() }
+pub fn read_instant() -> Instant { CLOCK.get().expect("init() not called").read_instant() }
+
+// Allow external code to register a vdso-like update callback
+pub fn register_vdso_update_callback(cb: Arc<dyn Fn(Instant, u64) + Sync + Send>) {
+    let _ = VDSO_DATA_HIGH_RES_UPDATE_FN.set(cb);
+}
+
+// --------- Simple trace facility for DFSan-friendly logging ----------
+static TRACE: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn trace_record(event: &str) {
+    let vec = TRACE.get_or_init(|| Mutex::new(Vec::new()));
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    vec.lock().unwrap().push(format!("{}:{}", ts, event));
+}
+
+pub fn take_trace() -> Vec<String> {
+    TRACE
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap()
+        .drain(..)
+        .collect()
+}
+


### PR DESCRIPTION
Extract `kernel/comps/time` into a user-mode library with `ostd` stubs and a demo app, enabling DFSan instrumentation and API tracing.

The original `time` module was deeply integrated with kernel-specific `ostd` APIs. This PR refactors it to run in user-mode by replacing these kernel dependencies with standard library equivalents and simple stubs, allowing for easier testing and dynamic analysis (like DFSan) in a user-space environment. It also includes a basic tracing mechanism to record API calls for analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-bba8999b-f9e4-4290-916d-f20faf5749e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bba8999b-f9e4-4290-916d-f20faf5749e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

